### PR TITLE
Mob session

### DIFF
--- a/go-chaos/internal/labels.go
+++ b/go-chaos/internal/labels.go
@@ -16,6 +16,7 @@ package internal
 
 import (
 	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -76,6 +77,30 @@ func (c K8Client) getGatewayLabels() string {
 		return getSaasGatewayLabels()
 	} else {
 		return getSelfManagedGatewayLabels()
+	}
+}
+
+func getSelfManagedCoreLabels() string {
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: map[string]string{"app.kubernetes.io/component": "core"},
+	}
+	return labels.Set(labelSelector.MatchLabels).String()
+}
+
+func getSaasCoreLabels() string {
+	// For backwards compatability the brokers kept the core labels, for a statefulset the labels are not modifiable
+	// To still be able to distinguish the standalone core with the broker, the gateway got a new label.
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: map[string]string{"app.kubernetes.io/app": "zeebe-gateway", "app.kubernetes.io/component": "standalone-gateway"},
+	}
+	return labels.Set(labelSelector.MatchLabels).String()
+}
+
+func (c K8Client) GetCoreLabels() string {
+	if c.SaaSEnv {
+		return getSaasCoreLabels()
+	} else {
+		return getSelfManagedCoreLabels()
 	}
 }
 

--- a/go-chaos/internal/statefulset_test.go
+++ b/go-chaos/internal/statefulset_test.go
@@ -72,10 +72,13 @@ func Test_ShouldReturnErrorForNonExistingStatefulSetInSaaS(t *testing.T) {
 	k8Client.createSaaSCRD(t)
 
 	// when
-	statefulset, err := k8Client.GetZeebeStatefulSet()
+	_, err := k8Client.GetZeebeStatefulSet()
 
 	// then
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "statefulsets.apps \"zeebe\" not found")
-	assert.Nil(t, statefulset)
+
+	// API No longer returns nil pointer but empty initialized struct
+	//assert.Nil(t, statefulset)
+
 }

--- a/go-chaos/worker/chaos_worker_test.go
+++ b/go-chaos/worker/chaos_worker_test.go
@@ -188,7 +188,7 @@ func Test_ShouldSendExperimentsForClusterPlan(t *testing.T) {
 	assert.True(t, fakeJobClient.Succeeded)
 	assert.Equal(t, 123, fakeJobClient.Key)
 	// as we don't have a version in this test, we should omit version bounded experiments
-	experiments, err := chaos_experiments.ReadExperimentsForClusterPlan("Production - S", "")
+	experiments, err := chaos_experiments.ReadExperimentsForClusterPlan("Production - S", "8.8.0")
 	require.NoError(t, err)
 	assert.Equal(t, experiments, fakeJobClient.Variables)
 }


### PR DESCRIPTION
- Allow chaos client to retrieve k8s pod Labels/Names from the new deployment labels
- Adjust tests to align with updated k8s client dependency 