### PR TITLE
ci: update go version in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
         default: 'zbchaos-v1.X.0'
 
 env:
-  GO_VERSION: 1.19
+  GO_VERSION: 1.23
 
 jobs:
  go-release:


### PR DESCRIPTION
Required to release again, otherwise we can't work with our go.mod: https://github.com/camunda/zeebe-chaos/actions/runs/16437984427/job/46453776679