### PR TITLE
fix: still use plaintext connection with authentication

### DIFF
--- a/go-chaos/internal/zeebe.go
+++ b/go-chaos/internal/zeebe.go
@@ -48,10 +48,7 @@ func CreateZeebeClient(port int, credentials *ClientCredentials) (zbc.Client, er
 		if err != nil {
 			return nil, err
 		}
-		if credsProvider != nil {
-			clientConfig.CredentialsProvider = credsProvider
-			clientConfig.UsePlaintextConnection = false
-		}
+		clientConfig.CredentialsProvider = credsProvider
 	}
 
 	client, err := zbc.NewClient(clientConfig)


### PR DESCRIPTION
We still port-forward and thus bypass TLS, even if we now use authentication