### PR TITLE
fix: read worker template from embedded file

### DIFF
--- a/go-chaos/internal/deployment.go
+++ b/go-chaos/internal/deployment.go
@@ -57,9 +57,12 @@ func (c K8Client) CreateWorkerDeploymentDefault() error {
 }
 
 func (c K8Client) CreateWorkerDeployment(dockerImageTag string, pollingDelayMs int, credentials *ClientCredentials) error {
-	filename := "manifests/worker.yaml"
-	// the tempalte name must be the filename
-	tmpl, err := template.New("worker.yaml").ParseFiles(filename)
+	templateFile, err := k8Deployments.ReadFile("manifests/worker.yaml")
+	if err != nil {
+		return err
+	}
+	// the template name must be the filename
+	tmpl, err := template.New("worker.yaml").Parse(string(templateFile))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
e507f1f87b2374d2a64dc4d63cf3060cdc8e6cd1 introduced a bug by not reading from the files embedded in the binary.