### PR TITLE
fix: support legacy scaling endpoint for Zeebe <8.6

### DIFF
--- a/go-chaos/cmd/cluster.go
+++ b/go-chaos/cmd/cluster.go
@@ -17,14 +17,13 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
-	"net/http"
-	"strings"
-	"time"
-
 	"github.com/camunda/zeebe-chaos/go-chaos/internal"
 	"github.com/spf13/cobra"
+	"io"
+	"net/http"
+	"time"
 )
 
 func AddClusterCommands(rootCmd *cobra.Command, flags *Flags) {
@@ -234,6 +233,9 @@ func sendScaleRequestLegacy(port int, brokerIds []int32, force bool, replication
 	resp, err := http.Post(url, "application/json", bytes.NewReader(request))
 	if err != nil {
 		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("received nil response from server")
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("scaling failed with code %d", resp.StatusCode)

--- a/go-chaos/cmd/cluster.go
+++ b/go-chaos/cmd/cluster.go
@@ -161,7 +161,8 @@ func sendScaleRequest(port int, brokerIds []int32, partitionCount int32, force b
 	}
 
 	// if it failed due to 405, fall back
-	if strings.Contains(err.Error(), "code 405") {
+	var httpErr *http.Response
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusMethodNotAllowed {
 		internal.LogInfo("PATCH endpoint not supported, falling back to legacy endpoint…")
 		return sendScaleRequestLegacy(port, brokerIds, force, replicationFactor)
 	}

--- a/go-chaos/cmd/cluster.go
+++ b/go-chaos/cmd/cluster.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/camunda/zeebe-chaos/go-chaos/internal"
@@ -155,10 +156,17 @@ func sendScaleRequest(port int, brokerIds []int32, partitionCount int32, force b
 	clusterRequest := (&ClusterPatchRequest{}).withBrokers(brokerIds).withPartitions(partitionCount, replicationFactor)
 
 	changeResponse, err := sendPatchCluster(port, force, *clusterRequest)
-	if err != nil {
-		return nil, err
+	if err == nil {
+		return changeResponse, err
 	}
-	return changeResponse, nil
+
+	// if it failed due to 405, fall back
+	if strings.Contains(err.Error(), "code 405") {
+		internal.LogInfo("PATCH endpoint not supported, falling back to legacy endpoint…")
+		return sendScaleRequestLegacy(port, brokerIds, force, replicationFactor)
+	}
+
+	return nil, err
 }
 
 func sendPatchCluster(port int, force bool, clusterRequest ClusterPatchRequest) (*ChangeResponse, error) {
@@ -202,6 +210,49 @@ func sendHTTPJsonRequest(url, method string, body []byte) (*http.Response, error
 		return nil, err
 	}
 	return resp, nil
+}
+
+// sendScaleRequestLegacy implements the old behavior:
+//
+//	POST http://…/actuator/cluster/brokers?force=…&replicationFactor=…
+//	with a JSON body of brokerIds to support 8.5 chaos tests
+func sendScaleRequestLegacy(port int, brokerIds []int32, force bool, replicationFactor int32) (*ChangeResponse, error) {
+	forceParam := "false"
+	if force {
+		forceParam = "true"
+	}
+	url := fmt.Sprintf("http://localhost:%d/actuator/cluster/brokers?force=%s", port, forceParam)
+	if replicationFactor > 0 {
+		url = url + fmt.Sprintf("&replicationFactor=%d", replicationFactor)
+	}
+	request, err := json.Marshal(brokerIds)
+	if err != nil {
+		return nil, err
+	}
+	internal.LogInfo("Requesting scaling %s with input  %s", url, request)
+	resp, err := http.Post(url, "application/json", bytes.NewReader(request))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("scaling failed with code %d", resp.StatusCode)
+	}
+
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(resp.Body)
+
+	response, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var changeResponse ChangeResponse
+	err = json.Unmarshal(response, &changeResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &changeResponse, nil
 }
 
 func printCurrentTopology(flags *Flags) error {


### PR DESCRIPTION
## Description

This PR makes the chaos‐test client compatible with both pre‑8.6 and post‑8.6 Zeebe clusters by:
* Attempting the new PATCH /actuator/cluster scaling endpoint first
* Falling back to the legacy POST /actuator/cluster/brokers endpoint on a 405 Method Not Allowed

In Zeebe 8.6 the cluster‐scaling actuator was changed from a “GET‐style” URL under `/actuator/cluster/brokers` to a PATCH `/actuator/cluster` endpoint with a richer JSON payload. See related change https://github.com/camunda/camunda/commit/e6a0dc5def76548ce157c5a69ab090bb0a9cb724. Our chaos tests were updated accordingly, but now fail when run against 8.5 brokers (which still only support the old URL/verb).

### What's Changed?
* Refactor `sendScaleRequest`
  * Builds a `ClusterPatchRequest` and calls `sendPatchCluster(...)`
  * On success, returns immediately
  * If `sendPatchCluster` returns a 405 error, logs a fallback notice and calls `sendScaleRequestLegacy(...)`
* New helper `sendScaleRequestLegacy`
  * Encapsulates the original GET‑style scaling call to `/actuator/cluster/brokers?force=…&replicationFactor=…` with a JSON body of broker IDs

### Links
CI Failures: [1](https://camunda.slack.com/archives/C013MEVQ4M9/p1753671943100509), [2](https://camunda.slack.com/archives/C013MEVQ4M9/p1753758029969889)
Incident channel: [#inc-investigate-qa-failing](https://camunda.slack.com/archives/C09881L39PB)