### PR TITLE
fix: log worker deployment config with json info

### DIFF
--- a/go-chaos/internal/deployment.go
+++ b/go-chaos/internal/deployment.go
@@ -77,7 +77,7 @@ func (c K8Client) CreateWorkerDeployment(dockerImageTag string, pollingDelayMs i
 	if err != nil {
 		return err
 	}
-	fmt.Println("Template execute is ", workerBuilder.String())
+	LogInfo("Deploying worker with config:\n%s", workerBuilder.String())
 	workerBytes := []byte(workerBuilder.String())
 
 	LogVerbose("Deploy worker deployment to the current namespace: %s", c.GetCurrentNamespace())


### PR DESCRIPTION
Using fmt.Println results in the config being spread out across many log lines as the config is a multi-line string and \n is interpreted as new log lines. Additionally, using fmt.Println means that we're missing out on any added labels like processInstanceKey or clusterId.

We can change this by using LogInfo or LogVerbose. I've chosen LogInfo here as we can log the config together with a stronger statement that we're deploying the worker now.