### PR TITLE
fix: failover must remove brokers from other region

### DIFF
--- a/go-chaos/cmd/cluster.go
+++ b/go-chaos/cmd/cluster.go
@@ -357,9 +357,9 @@ func forceFailover(flags *Flags) error {
 		return fmt.Errorf("cluster is already scaling")
 	}
 
-	brokersInRegion := getBrokers(currentTopology, flags.regions, flags.regionId)
+	brokersToRemove := getBrokersToRemove(currentTopology, flags.regions, flags.regionId)
 
-	changeResponse, err := sendScaleRequest(port, brokersInRegion, 0, true, -1)
+	changeResponse, err := sendScaleRequest(port, brokersToRemove, 0, true, -1)
 	ensureNoError(err)
 
 	timeout := time.Minute * 5
@@ -369,10 +369,10 @@ func forceFailover(flags *Flags) error {
 	return nil
 }
 
-func getBrokers(topology *CurrentTopology, regions int32, regionId int32) []int32 {
+func getBrokersToRemove(topology *CurrentTopology, regions int32, regionId int32) []int32 {
 	brokersInRegion := make([]int32, 0)
 	for _, b := range topology.Brokers {
-		if b.Id%regions == regionId {
+		if b.Id%regions != regionId {
 			brokersInRegion = append(brokersInRegion, b.Id)
 		}
 	}

--- a/go-chaos/cmd/cluster.go
+++ b/go-chaos/cmd/cluster.go
@@ -357,7 +357,7 @@ func forceFailover(flags *Flags) error {
 		return fmt.Errorf("cluster is already scaling")
 	}
 
-	brokersToRemove := getBrokersToRemove(currentTopology, flags.regions, flags.regionId)
+	brokersToRemove := getBrokersInOtherRegions(currentTopology, flags.regions, flags.regionId)
 
 	changeResponse, err := sendScaleRequest(port, brokersToRemove, 0, true, -1)
 	ensureNoError(err)
@@ -369,15 +369,15 @@ func forceFailover(flags *Flags) error {
 	return nil
 }
 
-func getBrokersToRemove(topology *CurrentTopology, regions int32, regionId int32) []int32 {
-	brokersInRegion := make([]int32, 0)
+func getBrokersInOtherRegions(topology *CurrentTopology, regions int32, regionId int32) []int32 {
+	brokersInOtherRegions := make([]int32, 0)
 	for _, b := range topology.Brokers {
 		if b.Id%regions != regionId {
-			brokersInRegion = append(brokersInRegion, b.Id)
+			brokersInOtherRegions = append(brokersInOtherRegions, b.Id)
 		}
 	}
 
-	return brokersInRegion
+	return brokersInOtherRegions
 }
 
 type ChangeStatus string

--- a/go-chaos/cmd/cluster_test.go
+++ b/go-chaos/cmd/cluster_test.go
@@ -148,3 +148,21 @@ func Test_ClusterPatchRequestJsonReplicationFactorOnly(t *testing.T) {
 	expected := `{"brokers":null,"partitions":{"count":null,"replicationFactor":3}}`
 	assert.Equal(t, expected, string(json))
 }
+
+func Test_BrokersToRemoveCalculation(t *testing.T) {
+	// given
+	currentTopology := CurrentTopology{
+		Brokers: []BrokerState{
+			{Id: 0},
+			{Id: 1},
+			{Id: 2},
+			{Id: 3},
+		},
+	}
+
+	// when - failing over to region 0
+	brokersToRemove := getBrokersToRemove(&currentTopology, 2, 0)
+
+	// then - brokers in region 1 should be removed
+	assert.Equal(t, []int32{1, 3}, brokersToRemove)
+}

--- a/go-chaos/cmd/cluster_test.go
+++ b/go-chaos/cmd/cluster_test.go
@@ -149,7 +149,7 @@ func Test_ClusterPatchRequestJsonReplicationFactorOnly(t *testing.T) {
 	assert.Equal(t, expected, string(json))
 }
 
-func Test_BrokersToRemoveCalculation(t *testing.T) {
+func Test_BrokersInOtherRegionsCalculation(t *testing.T) {
 	// given
 	currentTopology := CurrentTopology{
 		Brokers: []BrokerState{
@@ -161,8 +161,8 @@ func Test_BrokersToRemoveCalculation(t *testing.T) {
 	}
 
 	// when - failing over to region 0
-	brokersToRemove := getBrokersToRemove(&currentTopology, 2, 0)
+	brokersInOtherRegions := getBrokersInOtherRegions(&currentTopology, 2, 0)
 
 	// then - brokers in region 1 should be removed
-	assert.Equal(t, []int32{1, 3}, brokersToRemove)
+	assert.Equal(t, []int32{1, 3}, brokersInOtherRegions)
 }


### PR DESCRIPTION
Fixes a bug introduced with https://github.com/camunda/zeebe-chaos/pull/682 where we were removing brokers from the region that we wanted to failover _to_. We must remove the brokers from the _other_ region instead.

Example of bad behavior before:

```
Running command with args: [--cluster forceFailover --regions=2 --regionId=0] 
Requesting scaling http://localhost:41617/actuator/cluster?force=true with input {"brokers":{"remove":[2,0]},"partitions":null}
```

Here, brokers 0 and 2 are from region 0, we want to remove brokers 1 and 3 instead.

Closes #684