### PR TITLE
feat: do not wait partition scaling to complete

### DIFF
--- a/go-chaos/cmd/cluster.go
+++ b/go-chaos/cmd/cluster.go
@@ -115,8 +115,6 @@ func scaleCluster(flags *Flags) error {
 func scalePartitions(k8Client internal.K8Client, port int, partitionCount int32, replicationFactor int32) (*ChangeResponse, error) {
 	changeResponse, err := sendScaleRequest(port, nil, partitionCount, false, replicationFactor)
 	ensureNoError(err)
-	timeout := time.Minute * 5
-	err = waitForChange(port, changeResponse.ChangeId, timeout)
 	return changeResponse, nil
 }
 


### PR DESCRIPTION
When scaling partition, zbchaos doesn't wait anymore for the change to be completed. This opens the possibility to inject chaos when the scaling is happening.

The other cluster commands are not modified as it may break some existing experiment