### PR TITLE
feat: added new test case for dynamic scaling

### DIFF
--- a/go-chaos/internal/chaos-experiments/camunda-cloud/manifest.yml
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/manifest.yml
@@ -67,6 +67,10 @@ experiments:
     clusterPlans:
       - production-s
     minVersion: 8.4
+  - path: scaling/broker-partition-scaling.json
+    clusterPlans:
+      - production-s
+    minVersion: 8.8
   # only for testing
   - path: test/experiment.json
     clusterPlans:

--- a/go-chaos/internal/chaos-experiments/camunda-cloud/scaling/broker-partition-scaling.json
+++ b/go-chaos/internal/chaos-experiments/camunda-cloud/scaling/broker-partition-scaling.json
@@ -1,0 +1,166 @@
+{
+    "version": "0.1.0",
+    "title": "Zeebe partitions & brokers scaling experiment",
+    "description": "Partitions and brokers can be scaled up and Zeebe can continue processing after scaling up.",
+    "contributions": {
+        "reliability": "high"
+    },
+    "steady-state-hypothesis": {
+        "title": "Zeebe is alive",
+        "probes": [
+            {
+                "name": "All pods should be ready",
+                "type": "probe",
+                "tolerance": 0,
+                "provider": {
+                    "type": "process",
+                    "path": "zbchaos",
+                    "arguments": [
+                        "verify",
+                        "readiness"
+                    ],
+                    "timeout": 900
+                }
+            }
+        ]
+    },
+    "method": [
+        {
+            "name": "Deploy process model with catch event",
+            "type": "action",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": [
+                    "deploy",
+                    "process",
+                    "--processModelPath",
+                    "bpmn/msg-catch.bpmn"
+                ]
+            }
+        },
+        {
+            "type": "action",
+            "name": "Publish message to partition three",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": [
+                    "publish",
+                    "--partitionId",
+                    "3"
+                ]
+            }
+        },
+        {
+            "type": "action",
+            "name": "Scale up brokers",
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": [
+                    "cluster",
+                    "scale",
+                    "--partitionCount",
+                    "4",
+                    "--brokers",
+                    "5"
+                ]
+            }
+        },
+        {
+            "type": "action",
+            "name": "Wait for scale up to complete",
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": [
+                    "cluster",
+                    "wait"
+                ],
+                "timeout": 900
+            }
+        },
+        {
+            "name": "All pods should be ready",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": [
+                    "verify",
+                    "readiness"
+                ],
+                "timeout": 900
+            }
+        },
+        {
+            "name": "Should be able to create a process instance and await the message correlation that was published before scaling.",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": [
+                    "verify",
+                    "instance-creation",
+                    "--awaitResult",
+                    "--bpmnProcessId",
+                    "oneReceiveMsgEvent",
+                    "--variables",
+                    "{\"key\": \"2\"}"
+                ]
+            }
+        },
+        {
+            "type": "action",
+            "name": "Publish message",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": [
+                    "publish"
+                ]
+            }
+        },
+        {
+            "name": "Should be able to create a process instance in the new partition and await the message correlation that was published after scaling to a new partition.",
+            "type": "probe",
+            "tolerance": 0,
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": [
+                    "verify",
+                    "instance-creation",
+                    "--partitionId",
+                    "4",
+                    "--awaitResult",
+                    "--bpmnProcessId",
+                    "oneReceiveMsgEvent",
+                    "--variables",
+                    "{\"key\": \"4\"}"
+                ]
+            }
+        },
+        {
+            "type": "action",
+            "name": "Scale down brokers (rollback)",
+            "provider": {
+                "type": "process",
+                "path": "zbchaos",
+                "arguments": [
+                    "cluster",
+                    "scale",
+                    "--brokers",
+                    "3"
+                ]
+            }
+        }
+    ],
+    "rollbacks": []
+}


### PR DESCRIPTION
Similar to broker-scaling.json, but the number of partitions is scaled to 4 (on top of broker scaling).

Since new partitions do not participate in message correlation, there is no test in verifying that messages are published to the new partition. However, a new process instance is created on the new partition, receiving a message from another partition.

Brokers are scaled back to 3 when done, but partitions cannot be scaled back.